### PR TITLE
re-initialise chrome if disconnected

### DIFF
--- a/webapp/src/chropro/Main.java
+++ b/webapp/src/chropro/Main.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 public class Main {
-    public static void main(String args[]) throws ExecutionException, InterruptedException, IOException {
+    public static void main(String args[]) throws ExecutionException, InterruptedException, IOException, TimeoutException {
         String chromeHost = "127.0.0.1";
         int chromePort = 9292;
 

--- a/webapp/src/chropro/Renderer.java
+++ b/webapp/src/chropro/Renderer.java
@@ -13,7 +13,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class Renderer implements AutoCloseable {
 
-
     private Chropro chrome;
     private final String chromeHost;
     private final int chromePort;
@@ -41,6 +40,7 @@ public class Renderer implements AutoCloseable {
             try {
                 targetId = chrome.target.createTarget("about:blank", w, h, contextId).get(timeout, MILLISECONDS).targetId;
             } catch (WebsocketNotConnectedException ex) {
+                System.out.println("Lost connection to web service. Re-initialising chrome client.");
                 init();
                 targetId = chrome.target.createTarget("about:blank", w, h, contextId).get(timeout, MILLISECONDS).targetId;
             }


### PR DESCRIPTION
@ato Probably not the greatest way to do this, but at least the webapp will automatically reconnect to the webservice if it loses its connection (i.e. the headless-chromium service gets restarted).