### PR TITLE
check socket ready state before closing or opening

### DIFF
--- a/client/src/chropro/Chropro.java
+++ b/client/src/chropro/Chropro.java
@@ -1,5 +1,7 @@
 package chropro;
 
+import org.java_websocket.WebSocket;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.String;


### PR DESCRIPTION
@ato Checking socket ready state before closing the connection. It was blowing up when it tried to close an already closed socket. 

Also added a check to see if it was already in the "connecting" state before trying to create another connection.